### PR TITLE
Fix laser in 1.17.1

### DIFF
--- a/src/main/java/fr/skytasul/guardianbeam/Laser.java
+++ b/src/main/java/fr/skytasul/guardianbeam/Laser.java
@@ -309,12 +309,14 @@ public class Laser {
 
 		static {
 			try {
+				// e.g. Bukkit.getServer().getClass().getPackage().getName() -> org.bukkit.craftbukkit.v1_17_R1
 				String[] versions = Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3].substring(1).split("_");
 				version = Integer.parseInt(versions[1]); // 1.X
 				if (version >= 17) {
-					versions = Bukkit.getBukkitVersion().split("_")[0].split("\\.");
+					// e.g. Bukkit.getBukkitVersion() -> 1.17.1-R0.1-SNAPSHOT
+					versions = Bukkit.getBukkitVersion().split("-R")[0].split("\\.");
 					versionMinor = versions.length <= 2 ? 0 : Integer.parseInt(versions[2]);
-				}else versionMinor = Integer.parseInt(versions[2].substring(1)); // 1.X.Y
+				} else versionMinor = Integer.parseInt(versions[2].substring(1)); // 1.X.Y
 				
 				String watcherName1 = null, watcherName2 = null, watcherName3 = null;
 				if (version < 13) {

--- a/src/main/java/fr/skytasul/guardianbeam/Laser.java
+++ b/src/main/java/fr/skytasul/guardianbeam/Laser.java
@@ -316,7 +316,7 @@ public class Laser {
 					// e.g. Bukkit.getBukkitVersion() -> 1.17.1-R0.1-SNAPSHOT
 					versions = Bukkit.getBukkitVersion().split("-R")[0].split("\\.");
 					versionMinor = versions.length <= 2 ? 0 : Integer.parseInt(versions[2]);
-				} else versionMinor = Integer.parseInt(versions[2].substring(1)); // 1.X.Y
+				}else versionMinor = Integer.parseInt(versions[2].substring(1)); // 1.X.Y
 				
 				String watcherName1 = null, watcherName2 = null, watcherName3 = null;
 				if (version < 13) {
@@ -375,7 +375,7 @@ public class Laser {
 				watcherRegister = getMethod(dataWatcherClass, "register");
 				if (version >= 15) watcherDirty = getMethod(dataWatcherClass, "markDirty");
 				packetSpawn = getNMSClass("network.protocol.game", "PacketPlayOutSpawnEntityLiving").getDeclaredConstructor(version < 17 ? new Class<?>[0] : new Class<?>[] { getNMSClass("world.entity", "EntityLiving") });
-				packetRemove = getNMSClass("network.protocol.game", "PacketPlayOutEntityDestroy").getDeclaredConstructor(version < 17 ? int[].class : int.class);
+				packetRemove = getNMSClass("network.protocol.game", "PacketPlayOutEntityDestroy").getDeclaredConstructor(version == 17 && versionMinor == 0 ? int.class : int[].class);
 				packetMetadata = getNMSClass("network.protocol.game", "PacketPlayOutEntityMetadata").getDeclaredConstructor(int.class, dataWatcherClass, boolean.class);
 				packetTeleport = getNMSClass("network.protocol.game", "PacketPlayOutEntityTeleport").getDeclaredConstructor(version < 17 ? new Class<?>[0] : new Class<?>[] { entityClass });
 				packetTeam = getNMSClass("network.protocol.game", "PacketPlayOutScoreboardTeam");


### PR DESCRIPTION
Hello !

Someone said there was an error in 1.17.1 in spigot forum : https://www.spigotmc.org/threads/trying-to-use-guardianbeamapi-but-nothing-happens.515238/

I searched and fixed it fast, so I PR it.

1. Constructor of PacketPlayOutEntityDestroy in 1.17 take "int" but in other versions (1.17.1, 1.16, ...) it's "int[]". You changed that in the createPacketsRemoveEntities method but not in constructor.
2. Get minor version in 1.17.1 generates an error because Bukkit.getBukkitVersion() returns _"1.17.1-R0.1-SNAPSHOT"_. So we have to get the part before "R0.1" then split with "." and not "_" to get minor version.

I tested the result and it works in 1.17.1. I think you can ignore 1.17 since it's a transition version (e.g. nobody plays in 1.16 because 1.16.1 and 1.16.2 have been released relatively fast after 1.16.)

Hope it helps you !