### PR TITLE
Fixed restart beam (#5), negative distanceSquared and check moveInternal if plugin is still null

### DIFF
--- a/src/main/java/fr/skytasul/guardianbeam/Laser.java
+++ b/src/main/java/fr/skytasul/guardianbeam/Laser.java
@@ -258,7 +258,7 @@ public abstract class Laser {
 		* @param start Location where laser will starts
 		* @param end Location where laser will ends
 		* @param duration Duration of laser in seconds (<i>-1 if infinite</i>)
-		* @param distance Distance where laser will be visible (<i>-1 is infinite</i>)
+		* @param distance Distance where laser will be visible (<i>-1 if infinite</i>)
 		* @see {@link Laser#durationInTicks} to make the duration in ticks
 		* @see {@link Laser#executeEnd} to add {@link Runnable}s to execute when the laser will stop
 		 */
@@ -352,7 +352,7 @@ public abstract class Laser {
 		* @param start Location where laser will starts. The Crystal laser do not handle decimal number, it will be rounded to blocks.
 		* @param end Location where laser will ends. The Crystal laser do not handle decimal number, it will be rounded to blocks.
 		* @param duration Duration of laser in seconds (<i>-1 if infinite</i>)
-		* @param distance Distance where laser will be visible (<i>-1 is infinite</i>)
+		* @param distance Distance where laser will be visible (<i>-1 if infinite</i>)
 		* @see {@link Laser#durationInTicks} to make the duration in ticks
 		* @see {@link Laser#executeEnd} to add {@link Runnable}s to execute when the laser will stop
 		 */


### PR DESCRIPTION
Hello !

This PR fixes three little things :

1. Fix issue #5, map `show` can contain players even if the beam has stopped. When the beam starts again, the packets won't be sent to the players that are in the range, they have to go outside then go inside. Fix is simply `show.clear();` when cancel method is called.
2. Method isCloseEnough has `distanceSquared == -1` condition, but this variable was calculated before with `distanceSquared = distance * distance`. I added a check if distance is negative, the distanceSquared value is -1.
3. If moveEnd or moveStart on smooth animations are called before the laser starts for the first time, its plugin field is null and the task in moveInternal cannot start. I added a Validate for more information in traceback if anyone does.

I also removed some unused variables in methods or throw error when it's the case. 