### PR TITLE
Fixed 1.16.x initialization

### DIFF
--- a/src/main/java/fr/skytasul/guardianbeam/Laser.java
+++ b/src/main/java/fr/skytasul/guardianbeam/Laser.java
@@ -1011,7 +1011,7 @@ public abstract class Laser {
 		V1_13(13, "ac", "bF", "bG", "b", "c", 70, 28),
 		V1_14(14, "W", "b", "bD", "c", "d", 73, 30),
 		V1_15(15, "T", "b", "bA", "c", "d", 74, 31),
-		V1_16(16, null, "b", "d", "c", "d", -1, 31, "u", null, null){
+		V1_16(16, null, "b", "d", "c", "d", -1, 31){
 			@Override
 			public int getSquidID() {
 				return Packets.versionMinor < 2 ? 74 : 81;


### PR DESCRIPTION
In the NMS class EntityTypes, the static field for end crystal in NMS 1.16.x is named `END_CRYSTAL` and has been changed to obfuscated `u` from 1.17, due to the drop of spigot mapping.

Thus, we don't want to initialize the mapping of 1.16 with the value `u` but the default `END_CRYSTAL` name.